### PR TITLE
refactor: Simplify using ki-unlifted. ...

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -94,7 +94,7 @@ jobs:
             aeson == 2.0.3.0,
             base == 4.15.1.0,
             exceptions == 0.10.4,
-            ki == 1.0.0,
+            ki-unlifted == 1.0.0.2,
             monad-logger == 0.3.36,
             om-show == 0.1.2.6,
             text == 1.2.5.0,

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /.stack-work
 /dist-newstyle
+/cabal.project.local
+/.tags.lock
+/tags
+*.full-imports
+

--- a/om-fork.cabal
+++ b/om-fork.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-fork
-version:             0.7.1.9
+version:             0.7.1.10
 synopsis:            Concurrency utilities.
 description:         Actor pattern and some limited structured concurrency
                      tools

--- a/om-fork.cabal
+++ b/om-fork.cabal
@@ -21,7 +21,7 @@ common dependencies
     , aeson        >= 2.0.3.0  && < 2.3
     , base         >= 4.15.1.0 && < 4.20
     , exceptions   >= 0.10.4   && < 0.11
-    , ki           >= 1.0.0    && < 1.1
+    , ki-unlifted  >= 1.0.0.2  && < 1.1
     , monad-logger >= 0.3.36   && < 0.4
     , om-show      >= 0.1.2.6  && < 0.2
     , text         >= 1.2.5.0  && < 2.2


### PR DESCRIPTION
Instead of doing our own MonadUliftIO stuff, just let `ki-unlifted` do it for
us.